### PR TITLE
Wrapper div does not need a background color.

### DIFF
--- a/src/players/Vimeo.js
+++ b/src/players/Vimeo.js
@@ -108,8 +108,7 @@ export class Vimeo extends Component {
     const style = {
       width: '100%',
       height: '100%',
-      overflow: 'hidden',
-      backgroundColor: 'black'
+      overflow: 'hidden'
     }
     return (
       <div


### PR DESCRIPTION
Sometimes a responsive video will have 1px on the side or bottom where this black poked through.